### PR TITLE
fix: prevent note duplication in UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,11 +305,10 @@ function displayNotes() {
     const notesGrid = document.getElementById('notesGrid');
     const notes = getNotesFromStorage();
     
-    // Clear existing notes (except the sample)
-    notesGrid.innerHTML = notesGrid.querySelector('.note-card') ? 
-        notesGrid.innerHTML : '';
+    // CLEAR the grid completely before re-rendering
+    notesGrid.innerHTML = '';
     
-    // Add notes from storage
+    // Add all notes from storage
     notes.forEach(note => {
         const noteElement = createNoteElement(note);
         notesGrid.prepend(noteElement);


### PR DESCRIPTION
## Known Issues
- **Note duplication bug**: New notes appear duplicated in UI until page refresh (data storage is correct). Will be addressed in separate fix.

## Testing Performed
- [x] Notes are saved to local storage
- [x] Notes persist after page refresh  
- [x] Delete functionality works correctly
- [x] Handles empty inputs with user alerts
- [x] Identified UI duplication issue (logged as #3)